### PR TITLE
First steps hooking up to LLVM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "llvm-hs"]
+	path = llvm-hs
+	url = git@github.com:muknio/llvm-hs

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
-packages: */*.cabal
+packages:
+  */*.cabal
+  llvm-hs/llvm-hs-pure/*.cabal
 
 package glow
   tests: True

--- a/glow/glow.cabal
+++ b/glow/glow.cabal
@@ -59,6 +59,7 @@ common shared-opts
     , sexpr-parser ^>=0.2.2
     , typed-process ^>=0.2.8
     , microlens ^>=0.4.12
+    , llvm-hs-pure ^>=12.0
   default-language:    Haskell2010
 
 library

--- a/glow/glow.cabal
+++ b/glow/glow.cabal
@@ -74,6 +74,7 @@ library
     , Glow.Prelude
     , Glow.Runtime.Interaction
     , Glow.Runtime.Interaction.STM
+    , Glow.Translate.LastLegToLLVM
     , Glow.Consensus.Local
     , Glow.Consensus.StateChannel
     , Glow.StateChannel
@@ -100,3 +101,4 @@ test-suite tests
   other-modules:
       Tests.Parser
     , Tests.Runtime.Interaction
+    , Tests.LastLegToLLVM

--- a/glow/lib/Glow/Ast/LastLeg.hs
+++ b/glow/lib/Glow/Ast/LastLeg.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- | This module defines an AST for Glow's last-leg intermediate
 -- representation, before generating LLVM code. We convert the data
 -- types in Glow.Gerbil.Types to this form before further translation.
@@ -44,7 +46,7 @@ data Module = Module
 
 -- | A variable
 newtype Var = Var LT.Text
-  deriving (Show, Read, Eq, Ord)
+  deriving (Show, Read, Eq, Ord, IsString)
 
 -- | A function definition. In addition to the parameters,
 -- return type, and body that exist in the surface language,

--- a/glow/lib/Glow/Ast/LastLeg.hs
+++ b/glow/lib/Glow/Ast/LastLeg.hs
@@ -77,7 +77,7 @@ data Type
   | TTuple [Type]
   deriving (Show, Read, Eq)
 
--- | A type for a "function pointer," named by analagy to C; these are
+-- | A type for a "function pointer," named by analogy to C; these are
 -- references to code, and cannot be constructed at runtime, but can
 -- be used to construct closures using 'ExCapture'.
 data FPtrType = FPtrType

--- a/glow/lib/Glow/Translate/LastLegToLLVM.hs
+++ b/glow/lib/Glow/Translate/LastLegToLLVM.hs
@@ -1,0 +1,40 @@
+module Glow.Translate.LastLegToLLVM where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text.Lazy as LT
+import qualified Glow.Ast.LastLeg as Ast
+import Glow.Prelude
+import LLVM.AST
+import LLVM.IRBuilder
+
+translateModule :: MonadModuleBuilder m => Ast.Module -> m ()
+translateModule m = do
+  for_ (M.toList (Ast.modExterns m)) $ \(v, ty) ->
+    -- TODO: this returns an Operand; store that somewhere so we
+    -- can refer to it in generated code? Or maybe we'll just
+    -- coordinate the name we pass in ourselves.
+    declareExtern v ty
+  pure () -- TODO: translate the actual code.
+
+declareExtern :: MonadModuleBuilder m => Ast.Var -> Ast.Type -> m Operand
+declareExtern v ty = case ty of
+  Ast.TFPtr fPtrTy -> declareExternFPtr v fPtrTy
+  Ast.TFunc fTy -> declareExternFunc v fTy
+  _ -> error $ "TODO: declareExtern with type = " <> show ty
+
+declareExternFPtr :: MonadModuleBuilder m => Ast.Var -> Ast.FPtrType -> m Operand
+declareExternFPtr _ _fPtrTy = undefined
+
+declareExternFunc :: MonadModuleBuilder m => Ast.Var -> Ast.FuncType -> m Operand
+declareExternFunc v fTy
+  | Ast.ftEffectful fTy = error "TODO: extern effectful functions"
+  | otherwise =
+      extern
+        (varToName v)
+        (map translateType (Ast.ftParams fTy))
+        (translateType (Ast.ftRetType fTy))
+
+varToName :: Ast.Var -> Name
+varToName (Ast.Var txt) = mkName $ LT.unpack txt
+
+translateType = undefined

--- a/glow/lib/Glow/Translate/LastLegToLLVM.hs
+++ b/glow/lib/Glow/Translate/LastLegToLLVM.hs
@@ -5,6 +5,7 @@ import qualified Data.Text.Lazy as LT
 import qualified Glow.Ast.LastLeg as Ast
 import Glow.Prelude
 import LLVM.AST
+import LLVM.AST.AddrSpace
 import LLVM.IRBuilder
 
 translateModule :: MonadModuleBuilder m => Ast.Module -> m ()
@@ -17,24 +18,61 @@ translateModule m = do
   pure () -- TODO: translate the actual code.
 
 declareExtern :: MonadModuleBuilder m => Ast.Var -> Ast.Type -> m Operand
-declareExtern v ty = case ty of
-  Ast.TFPtr fPtrTy -> declareExternFPtr v fPtrTy
-  Ast.TFunc fTy -> declareExternFunc v fTy
-  _ -> error $ "TODO: declareExtern with type = " <> show ty
-
-declareExternFPtr :: MonadModuleBuilder m => Ast.Var -> Ast.FPtrType -> m Operand
-declareExternFPtr _ _fPtrTy = undefined
-
-declareExternFunc :: MonadModuleBuilder m => Ast.Var -> Ast.FuncType -> m Operand
-declareExternFunc v fTy
-  | Ast.ftEffectful fTy = error "TODO: extern effectful functions"
-  | otherwise =
-      extern
-        (varToName v)
-        (map translateType (Ast.ftParams fTy))
-        (translateType (Ast.ftRetType fTy))
+declareExtern v ty = case translateType ty of
+  FunctionType {argumentTypes = args, resultType = ret, isVarArg = False} ->
+    extern (varToName v) args ret
+  _ ->
+    error "TODO: extern non-functions."
 
 varToName :: Ast.Var -> Name
 varToName (Ast.Var txt) = mkName $ LT.unpack txt
 
-translateType = undefined
+translateType :: Ast.Type -> Type
+translateType ty = case ty of
+  Ast.TTuple tys ->
+    ptr (tuple (map translateType tys))
+  Ast.TFunc fTy ->
+    -- A function is a pair of (function pointer, closure pointer)
+    tuple
+      [ mkFunctionType
+          opaquePtr
+          (Ast.ftParams fTy)
+          (Ast.ftRetType fTy),
+        opaquePtr
+      ]
+  Ast.TFPtr fPtrTy ->
+    -- A function pointer takes its closure as the first argument. TODO:
+    -- this doesn't match up with the TFunc case, where it's an opaque
+    -- pointer -- conceptually that's correct, since in TFunc it's basically
+    -- an exisistential, but not sure if we'll hit type errors from LLVM?
+    -- will have to revist.
+    let fTy = Ast.fptFuncType fPtrTy
+     in mkFunctionType
+          (translateType (Ast.TTuple (Ast.fptCaptures fPtrTy)))
+          (Ast.ftParams fTy)
+          (Ast.ftRetType fTy)
+
+mkFunctionType :: Type -> [Ast.Type] -> Ast.Type -> Type
+mkFunctionType captures args ret =
+  FunctionType
+    { isVarArg = False,
+      argumentTypes = captures : map translateType args,
+      resultType = translateType ret
+    }
+
+tuple :: [Type] -> Type
+tuple elts =
+  StructureType
+    { isPacked = False,
+      elementTypes = elts
+    }
+
+ptr :: Type -> Type
+ptr ty =
+  PointerType
+    { pointerReferent = ty,
+      pointerAddrSpace = AddrSpace 0
+    }
+
+opaquePtr :: Type
+opaquePtr = ptr (IntegerType 8)

--- a/glow/tests/Main.hs
+++ b/glow/tests/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Glow.Prelude
 import Test.Hspec
+import qualified Tests.LastLegToLLVM
 import qualified Tests.Parser
 import qualified Tests.Runtime.Interaction
 
@@ -9,3 +10,4 @@ main :: IO ()
 main = hspec $ do
   Tests.Parser.tests
   Tests.Runtime.Interaction.tests
+  Tests.LastLegToLLVM.tests

--- a/glow/tests/Tests/LastLegToLLVM.hs
+++ b/glow/tests/Tests/LastLegToLLVM.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 module Tests.LastLegToLLVM where
 
 import qualified Data.Map.Strict as M
 import qualified Glow.Ast.LastLeg as Ast
 import Glow.Prelude
 import qualified Glow.Translate.LastLegToLLVM as Trans
-import qualified LLVM.AST as LLVM
+import LLVM.AST
+import LLVM.AST.AddrSpace
+import LLVM.AST.CallingConvention
+import LLVM.AST.Global
+import LLVM.AST.Linkage
+import LLVM.AST.Visibility
 import qualified LLVM.IRBuilder as LLVM
 import Test.Hspec
 
@@ -18,6 +25,78 @@ tests = describe "Tests for Glow.Translate.LastLegToLLVM" $ do
               Ast.modFunDefs = M.empty
             }
       )
-      `shouldBe` LLVM.defaultModule
-        { LLVM.moduleName = "trivial"
+      `shouldBe` defaultModule
+        { moduleName = "trivial"
         }
+  describe "Tests for type translation" $ do
+    it "Should handle translating externs correctly." $ do
+      -- This is just one example; test more externs.
+      LLVM.buildModule
+        "myModule"
+        ( Trans.translateModule
+            Ast.Module
+              { Ast.modExterns =
+                  M.fromList
+                    [ ( "foo",
+                        Ast.TFPtr
+                          Ast.FPtrType
+                            { Ast.fptCaptures = [],
+                              Ast.fptFuncType =
+                                Ast.FuncType
+                                  { Ast.ftParams = [],
+                                    Ast.ftRetType = Ast.TTuple [],
+                                    Ast.ftEffectful = False
+                                  }
+                            }
+                      )
+                    ],
+                Ast.modFunDefs = M.empty
+              }
+        )
+        `shouldBe` defaultModule
+          { moduleName = "myModule",
+            moduleDefinitions =
+              [ GlobalDefinition
+                  Function
+                    { linkage = External,
+                      visibility = Default,
+                      dllStorageClass = Nothing,
+                      callingConvention = C,
+                      returnAttributes = [],
+                      returnType =
+                        PointerType
+                          { pointerReferent =
+                              StructureType
+                                { isPacked = False,
+                                  elementTypes = []
+                                },
+                            pointerAddrSpace = AddrSpace 0
+                          },
+                      name = Name "foo",
+                      parameters =
+                        ( [ Parameter
+                              PointerType
+                                { pointerReferent =
+                                    StructureType
+                                      { isPacked = False,
+                                        elementTypes = []
+                                      },
+                                  pointerAddrSpace = AddrSpace 0
+                                }
+                              (Name "")
+                              []
+                          ],
+                          False
+                        ),
+                      functionAttributes = [],
+                      section = Nothing,
+                      comdat = Nothing,
+                      alignment = 0,
+                      garbageCollectorName = Nothing,
+                      prefix = Nothing,
+                      basicBlocks = [],
+                      personalityFunction = Nothing,
+                      metadata = []
+                    }
+              ]
+          }

--- a/glow/tests/Tests/LastLegToLLVM.hs
+++ b/glow/tests/Tests/LastLegToLLVM.hs
@@ -1,0 +1,23 @@
+module Tests.LastLegToLLVM where
+
+import qualified Data.Map.Strict as M
+import qualified Glow.Ast.LastLeg as Ast
+import Glow.Prelude
+import qualified Glow.Translate.LastLegToLLVM as Trans
+import qualified LLVM.AST as LLVM
+import qualified LLVM.IRBuilder as LLVM
+import Test.Hspec
+
+tests = describe "Tests for Glow.Translate.LastLegToLLVM" $ do
+  it "Should compile an empty module correctly." $
+    LLVM.buildModule
+      "trivial"
+      ( Trans.translateModule
+          Ast.Module
+            { Ast.modExterns = M.empty,
+              Ast.modFunDefs = M.empty
+            }
+      )
+      `shouldBe` LLVM.defaultModule
+        { LLVM.moduleName = "trivial"
+        }


### PR DESCRIPTION
This pulls in `llvm-hs-pure` as a dependency, and kicks the tires on it by doing some translation of at least types in our last-leg IR to LLVM.

I had to vendor the package to get this working; see https://github.com/llvm-hs/llvm-hs/pull/389; when that is merged & released on hackage we can drop the submodule.

This is still a little bit WIP, but I fear if I wait until I've hit a clear milestone, the patch will be a large burden to review.