### PR TITLE
Types from pass project, strip out non-atom keys

### DIFF
--- a/glow/lib/Glow/Main.hs
+++ b/glow/lib/Glow/Main.hs
@@ -1,7 +1,6 @@
 module Glow.Main (main) where
 
 import qualified Glow.Gerbil.ImportSExpr as ISExp
-import Glow.Gerbil.ParseCommon (parseTypeTable)
 import Glow.Gerbil.ParseProject (extractPrograms)
 import Glow.Prelude
 import Text.Show.Pretty (pPrint)
@@ -26,7 +25,7 @@ main = do
           pPrint v
           pPrint (extractPrograms (ISExp.fedProject v))
           pPrint (ISExp.fedAnf v)
-          pPrint (parseTypeTable (ISExp.oSExpr (ISExp.fedTypeTable v)))
+          pPrint (ISExp.fedTypeTable v)
     _ -> do
       putStrLn "Usage: glow <path/to/glow/frontend> <source-file.glow>"
       exitFailure


### PR DESCRIPTION
An update/replacement of https://github.com/Glow-Lang/glow2-haskell/pull/3 that strips out non-atom keys instead of including them as `OrdSExpr` keys.