### PR TITLE
Add slots for metadata to ASTs which are missing them.

### DIFF
--- a/glow/lib/Glow/Ast/BlockParamPassing.hs
+++ b/glow/lib/Glow/Ast/BlockParamPassing.hs
@@ -24,19 +24,19 @@ import Glow.Prelude
 -- definition that acts as the "entry point", but for a one
 -- used as a library module there may be multiple interaction
 -- definitions.
-data Module = Module
-  { pTypes :: Map Id TypeDef,
-    pInteractions :: Map Id InteractionDef,
-    pFuncs :: Map Id FuncDef,
-    pInitBody :: Body
+data Module a = Module
+  { pTypes :: Map Id (TypeDef a),
+    pInteractions :: Map Id (InteractionDef a),
+    pFuncs :: Map Id (FuncDef a),
+    pInitBody :: Body a
   }
   deriving (Show, Read, Eq)
 
 -- |
 -- A 'Body' has a control-flow graph of blocks with a starting
 -- block label.
-data Body = Body
-  { bdyBlocks :: Map Id Block,
+data Body a = Body
+  { bdyBlocks :: Map Id (Block a),
     bdyStartBlock :: Id
   }
   deriving (Show, Read, Eq)
@@ -57,12 +57,12 @@ data Body = Body
 --    the eventual destination, or go another private block
 --    for the same participant and the same eventual
 --    destination.
-data Block = Block
+data Block a = Block
   { blkPartInfo :: BlockParticipantInfo,
     blkParams :: [Id],
     -- | if the block is private this should only have BsPartStmt with just that participant
-    blkStmts :: [BodyStmt],
-    blkBranch :: Branch
+    blkStmts :: [BodyStmt a],
+    blkBranch :: Branch a
   }
   deriving (Show, Read, Eq)
 
@@ -80,10 +80,10 @@ data EventualDestination
     EpdJump Id
   deriving (Show, Read, Eq)
 
-data Branch
-  = BrReturn Expr
-  | BrJump JumpTarget
-  | BrSwitch TrivExpr SwitchCase (Maybe JumpTarget)
+data Branch a
+  = BrReturn a Expr
+  | BrJump a JumpTarget
+  | BrSwitch a TrivExpr SwitchCase (Maybe JumpTarget)
   deriving (Show, Read, Eq)
 
 data JumpTarget = JumpTarget
@@ -98,37 +98,37 @@ data SwitchCase = SwitchCase
   }
   deriving (Show, Read, Eq)
 
-data TypeDef
-  = TdDefType [Id] Type
-  | TdDefData [Id] [Variant]
+data TypeDef a
+  = TdDefType a [Id] Type
+  | TdDefData a [Id] [Variant]
   deriving (Show, Read, Eq)
 
-data InteractionDef = InteractionDef
+data InteractionDef a = InteractionDef
   { idParticipants :: [Id],
     idAssets :: [Id],
     idParams :: [Id],
-    idBody :: Body
+    idBody :: Body a
   }
   deriving (Show, Read, Eq)
 
-data FuncDef = FuncDef
+data FuncDef a = FuncDef
   { fdPart :: (Maybe Id),
     fdCaptures :: [Id],
     fdParams :: [Id],
-    fdBody :: Body
+    fdBody :: Body a
   }
   deriving (Show, Read, Eq)
 
-data BodyStmt
-  = BsPartStmt (Maybe Id) PartStmt
-  | BsWithdraw Id (Record TrivExpr)
-  | BsDeposit Id (Record TrivExpr)
-  | BsPublish Id Id
+data BodyStmt a
+  = BsPartStmt a (Maybe Id) (PartStmt a)
+  | BsWithdraw a Id (Record TrivExpr)
+  | BsDeposit a Id (Record TrivExpr)
+  | BsPublish a Id Id
   deriving (Show, Read, Eq)
 
-data PartStmt
-  = PsDef Id Expr
-  | PsIgnore Expr
-  | PsRequire TrivExpr
-  | PsAssert TrivExpr
+data PartStmt a
+  = PsDef a Id Expr
+  | PsIgnore a Expr
+  | PsRequire a TrivExpr
+  | PsAssert a TrivExpr
   deriving (Show, Read, Eq)

--- a/glow/lib/Glow/Ast/LiftedFunctions.hs
+++ b/glow/lib/Glow/Ast/LiftedFunctions.hs
@@ -24,46 +24,46 @@ import Glow.Ast.Common
 import Glow.Gerbil.Types (Pat, Record, Type, Variant)
 import Glow.Prelude
 
-data Module = Module [TopStmt]
+data Module a = Module [TopStmt a]
   deriving (Show, Read, Eq)
 
-data TopStmt
-  = TsBodyStmt BodyStmt
+data TopStmt a
+  = TsBodyStmt (BodyStmt a)
   | -- Note: in the grammar there are both (deftype id type) and
     -- (deftype (id tyvar ...) type); here we just combine them, where the
     -- first variant has an empty list (likewise for defdata).
-    TsDefType Id [Id] Type
-  | TsDefData Id [Id] [Variant]
-  | TsDefInteraction Id InteractionDef
+    TsDefType a Id [Id] Type
+  | TsDefData a Id [Id] [Variant]
+  | TsDefInteraction a Id (InteractionDef a)
   | -- | participant id (if any), function id, function def:
-    TsDefLambda (Maybe Id) Id (Lambda BodyStmt)
+    TsDefLambda a (Maybe Id) Id (Lambda (BodyStmt a))
   deriving (Show, Read, Eq)
 
-data InteractionDef = InteractionDef
+data InteractionDef a = InteractionDef
   { idParticipants :: [Id],
     idAssets :: [Id],
     idParams :: [Id],
-    idBody :: [BodyStmt]
+    idBody :: [BodyStmt a]
   }
   deriving (Show, Read, Eq)
 
-data BodyStmt
-  = BsPartStmt (Maybe Id) PartStmt
-  | BsWithdraw Id (Record TrivExpr)
-  | BsDeposit Id (Record TrivExpr)
-  | BsPublish Id Id
-  | BsSwitch (Switch BodyStmt)
+data BodyStmt a
+  = BsPartStmt a (Maybe Id) (PartStmt a)
+  | BsWithdraw a Id (Record TrivExpr)
+  | BsDeposit a Id (Record TrivExpr)
+  | BsPublish a Id Id
+  | BsSwitch a (Switch (BodyStmt a))
   deriving (Show, Read, Eq)
 
-data PartStmt
-  = PsLabel Id
-  | PsDebugLabel Id
-  | PsDef Id Expr
-  | PsIgnore Expr
-  | PsReturn Expr
-  | PsRequire TrivExpr
-  | PsAssert TrivExpr
-  | PsSwitch (Switch PartStmt)
+data PartStmt a
+  = PsLabel a Id
+  | PsDebugLabel a Id
+  | PsDef a Id Expr
+  | PsIgnore a Expr
+  | PsReturn a Expr
+  | PsRequire a TrivExpr
+  | PsAssert a TrivExpr
+  | PsSwitch a (Switch (PartStmt a))
   deriving (Show, Read, Eq)
 
 data Switch stmt = Switch

--- a/glow/tests/Tests/FunctionLift.hs
+++ b/glow/tests/Tests/FunctionLift.hs
@@ -19,7 +19,7 @@ tests = describe "Glow.Translate.FunctionLift" $ do
         )
         Map.empty
       `shouldBe` Module
-        [TsBodyStmt (BsPartStmt Nothing (PsDef "x" (ExTriv (TrexConst (cInteger 3)))))]
+        [TsBodyStmt (BsPartStmt () Nothing (PsDef () "x" (ExTriv (TrexConst (cInteger 3)))))]
   it ("Should lift already-closed functions to the top without adding capture parameters") $
     do
       evalState
@@ -36,16 +36,17 @@ tests = describe "Glow.Translate.FunctionLift" $ do
         )
         Map.empty
       `shouldBe` Module
-        [ TsDefLambda Nothing "sqr" (Lambda [] ["x"] [BsPartStmt Nothing (PsReturn (ExApp (TrexVar "*") [TrexVar "x", TrexVar "x"]))]),
+        [ TsDefLambda () Nothing "sqr" (Lambda [] ["x"] [BsPartStmt () Nothing (PsReturn () (ExApp (TrexVar "*") [TrexVar "x", TrexVar "x"]))]),
           TsDefLambda
+            ()
             Nothing
             "sumsqr"
             ( Lambda
                 []
                 ["a", "b"]
-                [ BsPartStmt Nothing (PsDef "tmp" (ExApp (TrexVar "sqr") [TrexVar "a"])),
-                  BsPartStmt Nothing (PsDef "tmp0" (ExApp (TrexVar "sqr") [TrexVar "b"])),
-                  BsPartStmt Nothing (PsReturn (ExApp (TrexVar "+") [TrexVar "tmp", TrexVar "tmp0"]))
+                [ BsPartStmt () Nothing (PsDef () "tmp" (ExApp (TrexVar "sqr") [TrexVar "a"])),
+                  BsPartStmt () Nothing (PsDef () "tmp0" (ExApp (TrexVar "sqr") [TrexVar "b"])),
+                  BsPartStmt () Nothing (PsReturn () (ExApp (TrexVar "+") [TrexVar "tmp", TrexVar "tmp0"]))
                 ]
             )
         ]
@@ -63,15 +64,16 @@ tests = describe "Glow.Translate.FunctionLift" $ do
         )
         (execState (traverse fresh ["adder", "x", "add-x", "y", "+"]) Map.empty)
       `shouldBe` Module
-        [ TsDefLambda Nothing "add-x0" (Lambda ["x"] ["y"] [BsPartStmt Nothing (PsReturn (ExApp (TrexVar "+") [TrexVar "x", TrexVar "y"]))]),
+        [ TsDefLambda () Nothing "add-x0" (Lambda ["x"] ["y"] [BsPartStmt () Nothing (PsReturn () (ExApp (TrexVar "+") [TrexVar "x", TrexVar "y"]))]),
           TsDefLambda
+            ()
             Nothing
             "adder"
             ( Lambda
                 []
                 ["x"]
-                [ BsPartStmt Nothing (PsDef "add-x" (ExCapture (TrexVar "add-x0") [TrexVar "x"])),
-                  BsPartStmt Nothing (PsReturn (ExTriv (TrexVar "add-x")))
+                [ BsPartStmt () Nothing (PsDef () "add-x" (ExCapture (TrexVar "add-x0") [TrexVar "x"])),
+                  BsPartStmt () Nothing (PsReturn () (ExTriv (TrexVar "add-x")))
                 ]
             )
         ]
@@ -100,16 +102,17 @@ tests = describe "Glow.Translate.FunctionLift" $ do
         (execState (traverse fresh ["swap", "A", "B", "T", "U", "t", "u", "dlb1", "dlb2", "dlb3"]) Map.empty)
       `shouldBe` Module
         [ TsDefInteraction
+            ()
             "swap"
             ( InteractionDef
                 ["A", "B"]
                 ["T", "U"]
                 ["t", "u"]
-                [ BsDeposit "A" (Map.fromList [("T", TrexVar "t")]),
-                  BsDeposit "B" (Map.fromList [("U", TrexVar "u")]),
-                  BsWithdraw "B" (Map.fromList [("T", TrexVar "t")]),
-                  BsWithdraw "A" (Map.fromList [("U", TrexVar "u")]),
-                  BsPartStmt Nothing (PsReturn (ExTriv (TrexConst CUnit)))
+                [ BsDeposit () "A" (Map.fromList [("T", TrexVar "t")]),
+                  BsDeposit () "B" (Map.fromList [("U", TrexVar "u")]),
+                  BsWithdraw () "B" (Map.fromList [("T", TrexVar "t")]),
+                  BsWithdraw () "A" (Map.fromList [("U", TrexVar "u")]),
+                  BsPartStmt () Nothing (PsReturn () (ExTriv (TrexConst CUnit)))
                 ]
             )
         ]
@@ -141,18 +144,19 @@ tests = describe "Glow.Translate.FunctionLift" $ do
         (execState (traverse fresh ["buySig", "Buyer", "Seller", "DefaultToken", "digest0", "price", "dlb1", "signature", "tmp", "isValidSignature", "dlb2"]) Map.empty)
       `shouldBe` Module
         [ TsDefInteraction
+            ()
             "buySig"
             ( InteractionDef
                 ["Buyer", "Seller"]
                 ["DefaultToken"]
                 ["digest0", "price"]
-                [ BsDeposit "Buyer" (Map.fromList [("DefaultToken", TrexVar "price")]),
-                  BsPartStmt (Just "Seller") (PsDef "signature" (ExSign (TrexVar "digest0"))),
-                  BsPublish "Seller" "signature",
-                  BsPartStmt Nothing (PsDef "tmp" (ExApp (TrexVar "isValidSignature") [TrexVar "Seller", TrexVar "digest0", TrexVar "signature"])),
-                  BsPartStmt Nothing (PsRequire (TrexVar "tmp")),
-                  BsWithdraw "Seller" (Map.fromList [("DefaultToken", TrexVar "price")]),
-                  BsPartStmt Nothing (PsReturn (ExTriv (TrexConst CUnit)))
+                [ BsDeposit () "Buyer" (Map.fromList [("DefaultToken", TrexVar "price")]),
+                  BsPartStmt () (Just "Seller") (PsDef () "signature" (ExSign (TrexVar "digest0"))),
+                  BsPublish () "Seller" "signature",
+                  BsPartStmt () Nothing (PsDef () "tmp" (ExApp (TrexVar "isValidSignature") [TrexVar "Seller", TrexVar "digest0", TrexVar "signature"])),
+                  BsPartStmt () Nothing (PsRequire () (TrexVar "tmp")),
+                  BsWithdraw () "Seller" (Map.fromList [("DefaultToken", TrexVar "price")]),
+                  BsPartStmt () Nothing (PsReturn () (ExTriv (TrexConst CUnit)))
                 ]
             )
         ]


### PR DESCRIPTION
Namely the `LiftedFunctions` and `BlockParamPassing` ASTs; I started to look at writing a translation pass between these and found myself wanting to annotate AST nodes. So this patch adds a slot for misc. metadata, as it exists for other asts (Lurk, LowLevel, etc).