### PR TITLE
Add metadata slot to LiftedFunctions.Switch 

### DIFF
--- a/glow/lib/Glow/Ast/LiftedFunctions.hs
+++ b/glow/lib/Glow/Ast/LiftedFunctions.hs
@@ -52,7 +52,7 @@ data BodyStmt a
   | BsWithdraw a Id (Record TrivExpr)
   | BsDeposit a Id (Record TrivExpr)
   | BsPublish a Id Id
-  | BsSwitch a (Switch (BodyStmt a))
+  | BsSwitch a (Switch a (BodyStmt a))
   deriving (Show, Read, Eq)
 
 data PartStmt a
@@ -63,11 +63,12 @@ data PartStmt a
   | PsReturn a Expr
   | PsRequire a TrivExpr
   | PsAssert a TrivExpr
-  | PsSwitch a (Switch (PartStmt a))
+  | PsSwitch a (Switch a (PartStmt a))
   deriving (Show, Read, Eq)
 
-data Switch stmt = Switch
-  { swArg :: TrivExpr,
+data Switch a stmt = Switch
+  { swMeta :: a,
+    swArg :: TrivExpr,
     swBranches :: [(Pat, [stmt])]
   }
   deriving (Show, Read, Eq)

--- a/glow/lib/Glow/Translate/FunctionLift.hs
+++ b/glow/lib/Glow/Translate/FunctionLift.hs
@@ -134,11 +134,11 @@ liftTopStmt mpart locals = \case
         -- case for BsSwitch
         Nothing -> do
           cs2 <- liftSwitchCases mpart locals liftBodyStmts cs
-          tell [TsBodyStmt (BsSwitch () (Switch a cs2))]
+          tell [TsBodyStmt (BsSwitch () (Switch () a cs2))]
         -- case for PsSwitch
         Just _ -> do
           cs2 <- liftSwitchCases mpart locals liftPartStmts cs
-          tell [TsBodyStmt (BsPartStmt () mpart (PsSwitch () (Switch a cs2)))]
+          tell [TsBodyStmt (BsPartStmt () mpart (PsSwitch () (Switch () a cs2)))]
     )
   -- cases for PartStmt
   GGT.Label bs -> tell [TsBodyStmt (BsPartStmt () mpart (PsLabel () bs))]


### PR DESCRIPTION
...as opposed to an extra slot in the statement. This reduces redundancy and I'm finding it easier to work with.