### PR TITLE
Add functions for annotating the LiftedFunctions AST with free variables.

### DIFF
--- a/glow/glow.cabal
+++ b/glow/glow.cabal
@@ -110,7 +110,7 @@ test-suite tests
   hs-source-dirs: tests
   main-is: Main.hs
   other-modules:
-      Tests.AstCommon
+      Tests.Ast.Common
     , Tests.Parser
     , Tests.Runtime.Interaction
     , Tests.Fresh

--- a/glow/glow.cabal
+++ b/glow/glow.cabal
@@ -111,6 +111,7 @@ test-suite tests
   main-is: Main.hs
   other-modules:
       Tests.Ast.Common
+    , Tests.Ast.FreeVars
     , Tests.Parser
     , Tests.Runtime.Interaction
     , Tests.Fresh

--- a/glow/glow.cabal
+++ b/glow/glow.cabal
@@ -70,6 +70,7 @@ library
       Glow.Main
 
     , Glow.Ast.BlockParamPassing
+    , Glow.Ast.Classes
     , Glow.Ast.Common
     , Glow.Ast.Surface
     , Glow.Ast.HighLevel

--- a/glow/lib/Glow/Ast/Classes.hs
+++ b/glow/lib/Glow/Ast/Classes.hs
@@ -1,0 +1,5 @@
+module Glow.Ast.Classes where
+
+class HasMeta f where
+  getMeta :: f a -> a
+  setMeta :: a -> f a -> f a

--- a/glow/lib/Glow/Ast/Common.hs
+++ b/glow/lib/Glow/Ast/Common.hs
@@ -4,6 +4,8 @@
 module Glow.Ast.Common where
 
 import qualified Data.ByteString as BS
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Glow.Prelude
 
 -- | An identifier or variable
@@ -29,6 +31,10 @@ data TrivExpr
   = TrexVar Id
   | TrexConst Constant
   deriving (Show, Read, Eq)
+
+trexFreeVars :: TrivExpr -> Set Id
+trexFreeVars (TrexVar v) = Set.singleton v
+trexFreeVars (TrexConst _) = Set.empty
 
 cInteger :: Integer -> Constant
 cInteger i = CInt (intType i) i

--- a/glow/lib/Glow/Ast/LiftedFunctions.hs
+++ b/glow/lib/Glow/Ast/LiftedFunctions.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+
 -- | Module: Glow.Ast.LiftedFunctions
 --
 -- This module defines an Ast which is the output of the FunctionLift pass.
@@ -20,9 +23,13 @@
 -- form 'ExCapture' to supply capture-arguments to produce a closure.
 module Glow.Ast.LiftedFunctions where
 
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Glow.Ast.Classes
 import Glow.Ast.Common
-import Glow.Gerbil.Types (Pat, Record, Type, Variant)
+import Glow.Gerbil.Types (Pat, Record, Type, Variant, patVars)
 import Glow.Prelude
+import Prelude (head)
 
 data Module a = Module [TopStmt a]
   deriving (Show, Read, Eq)
@@ -39,6 +46,80 @@ data TopStmt a
     TsDefLambda a (Maybe Id) Id (Lambda (BodyStmt a))
   deriving (Show, Read, Eq)
 
+class HasMeta f => IsStmt f where
+  stmtsWithFreeVars :: [f a] -> [f (Set Id)]
+
+instance HasMeta TopStmt where
+  getMeta = \case
+    TsBodyStmt s -> getMeta s
+    TsDefType m _ _ _ -> m
+    TsDefData m _ _ _ -> m
+    TsDefInteraction m _ _ -> m
+    TsDefLambda m _ _ _ -> m
+  setMeta m = \case
+    TsBodyStmt s -> TsBodyStmt $ setMeta m s
+    TsDefType _ name params ty -> TsDefType m name params ty
+    TsDefData _ name params variants -> TsDefData m name params variants
+    TsDefInteraction _ name idef -> TsDefInteraction m name idef
+    TsDefLambda _ maybePart name lam -> TsDefLambda m maybePart name lam
+
+stmtsFreeVars :: HasMeta f => [f (Set Id)] -> Set Id
+stmtsFreeVars = \case
+  [] -> Set.empty
+  (s : _) -> getMeta s
+
+instance IsStmt TopStmt where
+  stmtsWithFreeVars = go
+    where
+      go [] = []
+      go (TsDefType _ _ _ _ : _) = error "TODO: TsDefType"
+      go (TsDefData _ _ _ _ : _) = error "TODO: TsDefData"
+      go (TsDefInteraction _ name idef : ss) =
+        let idef' = interactionDefWithFreeVars idef
+            defFvs = interactionDefFreeVars idef'
+            ss' = stmtsWithFreeVars ss
+            fvs = defFvs `Set.union` (Set.delete name (stmtsFreeVars ss'))
+         in TsDefInteraction fvs name idef' : ss'
+      go (TsDefLambda _ participant fName lam : tss) =
+        let body' = stmtsWithFreeVars (lamBody lam)
+            tail' = stmtsWithFreeVars tss
+            lam' =
+              Lambda
+                { lamCaptures = lamCaptures lam,
+                  lamParams = lamParams lam,
+                  lamBody = body'
+                }
+            defFvs =
+              Set.union
+                (foldMap Set.singleton participant)
+                ( stmtsFreeVars body'
+                    `Set.difference` Set.unions
+                      [ Set.fromList $ lamParams lam,
+                        Set.fromList $ lamCaptures lam,
+                        Set.singleton fName
+                      ]
+                )
+            tailFvs =
+              Set.delete fName (stmtsFreeVars tail')
+            retFvs = Set.union defFvs tailFvs
+         in TsDefLambda retFvs participant fName lam' : tail'
+      go (TsBodyStmt (BsPartStmt _ maybePart (PsDef _ v e)) : tss) =
+        let tss' = go tss
+            psFvs = exFreeVars e
+            fvs =
+              Set.unions
+                [ foldMap Set.singleton maybePart,
+                  psFvs,
+                  Set.delete v (stmtsFreeVars tss')
+                ]
+         in TsBodyStmt (BsPartStmt fvs maybePart (PsDef psFvs v e)) : tss'
+      go (TsBodyStmt b : ss) =
+        let ss' = stmtsWithFreeVars ss
+            b' = head $ stmtsWithFreeVars [b]
+            ssFvs = stmtsFreeVars ss'
+            headFvs = getMeta b'
+         in TsBodyStmt (setMeta (Set.union ssFvs headFvs) b') : ss'
+
 data InteractionDef a = InteractionDef
   { idParticipants :: [Id],
     idAssets :: [Id],
@@ -47,6 +128,19 @@ data InteractionDef a = InteractionDef
   }
   deriving (Show, Read, Eq)
 
+interactionDefWithFreeVars :: InteractionDef a -> InteractionDef (Set Id)
+interactionDefWithFreeVars InteractionDef {..} =
+  InteractionDef {idBody = stmtsWithFreeVars idBody, ..}
+
+interactionDefFreeVars :: InteractionDef (Set Id) -> Set Id
+interactionDefFreeVars InteractionDef {..} =
+  stmtsFreeVars idBody
+    `Set.difference` Set.unions
+      [ Set.fromList idParticipants,
+        Set.fromList idAssets,
+        Set.fromList idParams
+      ]
+
 data BodyStmt a
   = BsPartStmt a (Maybe Id) (PartStmt a)
   | BsWithdraw a Id (Record TrivExpr)
@@ -54,6 +148,68 @@ data BodyStmt a
   | BsPublish a Id Id
   | BsSwitch a (Switch a (BodyStmt a))
   deriving (Show, Read, Eq)
+
+instance HasMeta BodyStmt where
+  getMeta = \case
+    BsPartStmt m _ _ -> m
+    BsWithdraw m _ _ -> m
+    BsDeposit m _ _ -> m
+    BsPublish m _ _ -> m
+    BsSwitch m _ -> m
+  setMeta m = \case
+    BsPartStmt _ p s -> BsPartStmt m p s
+    BsWithdraw _ name record -> BsWithdraw m name record
+    BsDeposit _ name record -> BsDeposit m name record
+    BsPublish _ x y -> BsPublish m x y
+    BsSwitch _ sw -> BsSwitch m sw
+
+instance IsStmt BodyStmt where
+  stmtsWithFreeVars = go
+    where
+      go [] = []
+      go (BsPartStmt _ maybePart (PsDef _ v e) : ss) =
+        let ss' = go ss
+            psFvs = exFreeVars e
+            fvs =
+              Set.unions
+                [ foldMap Set.singleton maybePart,
+                  psFvs,
+                  Set.delete v (stmtsFreeVars ss')
+                ]
+         in BsPartStmt fvs maybePart (PsDef psFvs v e) : ss'
+      go (BsPartStmt _ maybePart p : ss) =
+        let p' = head $ stmtsWithFreeVars [p]
+         in chainTail
+              ss
+              (\fvs -> BsPartStmt fvs maybePart p')
+              (Set.union (getMeta p') (foldMap Set.singleton maybePart))
+      go (BsWithdraw _ v record : ss) =
+        chainTail
+          ss
+          (\fvs -> BsWithdraw fvs v record)
+          (Set.insert v (foldMap trexFreeVars record))
+      go (BsDeposit _ v record : ss) =
+        chainTail
+          ss
+          (\fvs -> BsDeposit fvs v record)
+          (Set.insert v (foldMap trexFreeVars record))
+      go (BsPublish _ x y : ss) =
+        chainTail
+          ss
+          (\fvs -> BsPublish fvs x y)
+          (Set.fromList [x, y])
+      go (BsSwitch _ sw : ss) =
+        let sw' = switchWithFreeVars sw
+            fvsSw = swMeta sw'
+         in chainTail
+              ss
+              (\fvs -> BsSwitch fvs sw')
+              fvsSw
+      chainTail :: [BodyStmt a] -> (Set Id -> BodyStmt (Set Id)) -> Set Id -> [BodyStmt (Set Id)]
+      chainTail ss ctor headFvs =
+        let ss' = go ss
+            fvs = Set.union headFvs (stmtsFreeVars ss')
+         in ctor fvs : ss'
 
 data PartStmt a
   = PsLabel a Id
@@ -66,12 +222,84 @@ data PartStmt a
   | PsSwitch a (Switch a (PartStmt a))
   deriving (Show, Read, Eq)
 
+instance HasMeta PartStmt where
+  getMeta = \case
+    PsLabel m _ -> m
+    PsDebugLabel m _ -> m
+    PsDef m _ _ -> m
+    PsIgnore m _ -> m
+    PsReturn m _ -> m
+    PsRequire m _ -> m
+    PsAssert m _ -> m
+    PsSwitch m _ -> m
+  setMeta m = \case
+    PsLabel _ lbl -> PsLabel m lbl
+    PsDebugLabel _ lbl -> PsDebugLabel m lbl
+    PsDef _ v e -> PsDef m v e
+    PsIgnore _ e -> PsIgnore m e
+    PsReturn _ e -> PsReturn m e
+    PsRequire _ e -> PsRequire m e
+    PsAssert _ e -> PsAssert m e
+    PsSwitch _ sw -> PsSwitch m sw
+
+instance IsStmt PartStmt where
+  stmtsWithFreeVars = go
+    where
+      go [] = []
+      go (PsLabel _ _ : ss) = go ss
+      go (PsDebugLabel _ _ : ss) = go ss
+      go (PsDef _ v e : ss) =
+        let ss' = go ss
+            fvs = Set.union (exFreeVars e) (Set.delete v (stmtsFreeVars ss'))
+         in PsDef fvs v e : ss'
+      go (PsIgnore _ e : ss) = chainEx PsIgnore exFreeVars e ss
+      go (PsReturn _ e : ss) = chainEx PsReturn exFreeVars e ss
+      go (PsRequire _ e : ss) = chainEx PsRequire trexFreeVars e ss
+      go (PsAssert _ e : ss) = chainEx PsAssert trexFreeVars e ss
+      go (PsSwitch _ sw : ss) =
+        let sw' = switchWithFreeVars sw
+            swFvs = swMeta sw'
+         in chainTail
+              ss
+              (\fvs -> PsSwitch fvs sw')
+              swFvs
+
+      chainTail ss ctor headFvs =
+        let ss' = go ss
+            fvs = Set.union headFvs (stmtsFreeVars ss')
+         in ctor fvs : ss'
+
+      chainEx :: (Set Id -> e -> PartStmt (Set Id)) -> (e -> Set Id) -> e -> [PartStmt a] -> [PartStmt (Set Id)]
+      chainEx ctor getEx e ss =
+        chainTail
+          ss
+          (\fvs -> ctor fvs e)
+          (getEx e)
+
 data Switch a stmt = Switch
   { swMeta :: a,
     swArg :: TrivExpr,
     swBranches :: [(Pat, [stmt])]
   }
   deriving (Show, Read, Eq)
+
+switchWithFreeVars :: IsStmt f => Switch a (f a) -> Switch (Set Id) (f (Set Id))
+switchWithFreeVars sw =
+  let branches = map goBranch (swBranches sw)
+      branchFvs =
+        foldMap
+          (\(_, fvs, _) -> fvs)
+          branches
+   in Switch
+        { swMeta = Set.union (trexFreeVars (swArg sw)) branchFvs,
+          swArg = swArg sw,
+          swBranches = [(p, stmts) | (p, _, stmts) <- branches]
+        }
+  where
+    goBranch (p, ss) =
+      let ss' = stmtsWithFreeVars ss
+          fvs = stmtsFreeVars ss'
+       in (p, Set.difference fvs (patVars p), ss')
 
 data Expr
   = ExTriv TrivExpr
@@ -88,6 +316,19 @@ data Expr
   | ExCapture TrivExpr [TrivExpr]
   | ExApp TrivExpr [TrivExpr]
   deriving (Show, Read, Eq)
+
+exFreeVars :: Expr -> Set Id
+exFreeVars (ExTriv e) = trexFreeVars e
+exFreeVars (ExDot e _) = trexFreeVars e
+exFreeVars (ExList es) = foldMap trexFreeVars es
+exFreeVars (ExTuple es) = foldMap trexFreeVars es
+exFreeVars (ExRecord es) = foldMap trexFreeVars es
+exFreeVars (ExEq x y) = Set.union (trexFreeVars x) (trexFreeVars y)
+exFreeVars (ExInput _ty e) = trexFreeVars e
+exFreeVars (ExDigest es) = foldMap trexFreeVars es
+exFreeVars (ExSign e) = trexFreeVars e
+exFreeVars (ExCapture e es) = foldMap trexFreeVars (e : es)
+exFreeVars (ExApp e es) = foldMap trexFreeVars (e : es)
 
 data Lambda stmt = Lambda
   { lamCaptures :: [Id],

--- a/glow/lib/Glow/Ast/LiftedFunctions.hs
+++ b/glow/lib/Glow/Ast/LiftedFunctions.hs
@@ -52,7 +52,7 @@ data BodyStmt a
   | BsWithdraw a Id (Record TrivExpr)
   | BsDeposit a Id (Record TrivExpr)
   | BsPublish a Id Id
-  | BsSwitch a (Switch (BodyStmt a))
+  | BsSwitch a (Switch a (BodyStmt a))
   deriving (Show, Read, Eq)
 
 data PartStmt a
@@ -63,11 +63,12 @@ data PartStmt a
   | PsReturn a Expr
   | PsRequire a TrivExpr
   | PsAssert a TrivExpr
-  | PsSwitch a (Switch (PartStmt a))
+  | PsSwitch a (Switch a (PartStmt a))
   deriving (Show, Read, Eq)
 
-data Switch stmt = Switch
-  { swArg :: TrivExpr,
+data Switch a stmt = Switch
+  { swMeta :: a,
+    swArg :: TrivExpr,
     swBranches :: [(Pat, [stmt])]
   }
   deriving (Show, Read, Eq)

--- a/glow/lib/Glow/Gerbil/Types.hs
+++ b/glow/lib/Glow/Gerbil/Types.hs
@@ -7,6 +7,8 @@ module Glow.Gerbil.Types where
 
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
+import Data.Set (Set)
+import qualified Data.Set as Set
 import GHC.Generics hiding (Datatype)
 import Glow.Ast.Common (Constant, Id, TrivExpr)
 import Glow.Prelude
@@ -116,6 +118,20 @@ data Pat
   | POr [Pat]
   | PConst Constant
   deriving (Show, Read, Eq)
+
+-- | 'patVars' returns a set of all variables bound by the pattern.
+patVars :: Pat -> Set Id
+patVars = go
+  where
+    go (PTypeAnno p _) = go p
+    go (PVar v) = Set.singleton v
+    go (PAppCtor _ ps) = foldMap go ps
+    go PWild = Set.empty
+    go (PList ps) = foldMap go ps
+    go (PTuple ps) = foldMap go ps
+    go (PRecord record) = foldMap go record
+    go (POr ps) = foldMap go ps -- TODO: check: what does the POr actually do?
+    go (PConst _) = Set.empty
 
 newtype LedgerPubKey = LedgerPubKey ByteString
   deriving stock (Generic, Eq, Show)

--- a/glow/lib/Glow/Translate/FunctionLift.hs
+++ b/glow/lib/Glow/Translate/FunctionLift.hs
@@ -134,11 +134,11 @@ liftTopStmt mpart locals = \case
         -- case for BsSwitch
         Nothing -> do
           cs2 <- liftSwitchCases mpart locals liftBodyStmts cs
-          tell [TsBodyStmt (BsSwitch () (Switch a cs2))]
+          tell [TsBodyStmt (BsSwitch () (Switch () a cs2))]
         -- case for PsSwitch
         Just _ -> do
           cs2 <- liftSwitchCases mpart locals liftPartStmts cs
-          tell [TsBodyStmt (BsPartStmt () mpart (PsSwitch () (Switch a cs2)))]
+          tell [TsBodyStmt (BsPartStmt () mpart (PsSwitch () (Switch () a cs2)))]
     )
   -- cases for PartStmt
   GGT.Label bs -> tell [TsBodyStmt (BsPartStmt () mpart (PsLabel () bs))]

--- a/glow/tests/Main.hs
+++ b/glow/tests/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Glow.Prelude
 import Test.Hspec
 import qualified Tests.Ast.Common
+import qualified Tests.Ast.FreeVars
 import qualified Tests.Fresh
 import qualified Tests.FunctionLift
 import qualified Tests.Lurk
@@ -12,6 +13,7 @@ import qualified Tests.Runtime.Interaction
 main :: IO ()
 main = hspec $ do
   Tests.Ast.Common.tests
+  Tests.Ast.FreeVars.tests
   Tests.Parser.tests
   Tests.Runtime.Interaction.tests
   Tests.Fresh.tests

--- a/glow/tests/Main.hs
+++ b/glow/tests/Main.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import Glow.Prelude
 import Test.Hspec
-import qualified Tests.AstCommon
+import qualified Tests.Ast.Common
 import qualified Tests.Fresh
 import qualified Tests.FunctionLift
 import qualified Tests.Lurk
@@ -11,7 +11,7 @@ import qualified Tests.Runtime.Interaction
 
 main :: IO ()
 main = hspec $ do
-  Tests.AstCommon.tests
+  Tests.Ast.Common.tests
   Tests.Parser.tests
   Tests.Runtime.Interaction.tests
   Tests.Fresh.tests

--- a/glow/tests/Tests/Ast/Common.hs
+++ b/glow/tests/Tests/Ast/Common.hs
@@ -1,4 +1,4 @@
-module Tests.AstCommon where
+module Tests.Ast.Common where
 
 import qualified Glow.Ast.Common
 import Glow.Prelude

--- a/glow/tests/Tests/Ast/FreeVars.hs
+++ b/glow/tests/Tests/Ast/FreeVars.hs
@@ -1,0 +1,144 @@
+module Tests.Ast.FreeVars (tests) where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Glow.Ast.Common
+import Glow.Ast.LiftedFunctions
+import Glow.Gerbil.Types (Pat (..))
+import Glow.Prelude
+import Test.Hspec
+
+tests = describe "Free variables" $ do
+  describe "Glow.Ast.Common" $ do
+    describe "trivial expressions" $
+      fvExamples
+        trexFreeVars
+        [ (TrexVar "x", ["x"]),
+          (TrexConst (CBool True), [])
+        ]
+  describe "Glow.Ast.LiftedFunctions" $ do
+    describe "expressions" $ do
+      fvExamples
+        exFreeVars
+        [ ( ExTriv (TrexVar "x"),
+            ["x"]
+          ),
+          ( ExDot (TrexVar "x") "y",
+            ["x"]
+          ),
+          ( ExList [TrexVar "x", TrexVar "y", TrexConst (CBool True), TrexVar "z"],
+            ["x", "y", "z"]
+          ),
+          ( ExTuple [TrexVar "x", TrexConst (CBool True), TrexVar "y"],
+            ["x", "y"]
+          ),
+          ( ExEq (TrexVar "x") (TrexVar "y"),
+            ["x", "y"]
+          ),
+          ( ExDigest [TrexVar "x"],
+            ["x"]
+          ),
+          ( ExSign (TrexVar "x"),
+            ["x"]
+          ),
+          ( ExCapture (TrexVar "f") [TrexVar "x", TrexVar "y"],
+            ["f", "x", "y"]
+          ),
+          ( ExApp (TrexVar "f") [TrexVar "x", TrexVar "y"],
+            ["f", "x", "y"]
+          )
+        ]
+    describe "switch statements" $ do
+      fvExamples (swMeta . switchWithFreeVars) $
+        [ ( Switch () (TrexVar "x") [],
+            ["x"]
+          ),
+          ( Switch () (TrexConst (CBool True)) $
+              [ (PWild, [PsAssert () (TrexVar "x")])
+              ],
+            ["x"]
+          ),
+          ( Switch () (TrexConst (CBool True)) $
+              [ (PVar "x", [PsAssert () (TrexVar "x")])
+              ],
+            []
+          ),
+          ( Switch () (TrexVar "x") $
+              [ (PConst (CBool True), [PsAssert () (TrexVar "y")]),
+                (PConst (CBool False), [PsAssert () (TrexVar "z")]),
+                (PVar "w", [PsAssert () (TrexVar "w")])
+              ],
+            ["x", "y", "z"]
+          )
+        ]
+    describe "PartStmts" $ do
+      describe "Simple examples" $ do
+        fvStmtsExamples
+          [ ( [],
+              []
+            ),
+            ( [PsLabel () "x"],
+              []
+            ),
+            ( [PsDebugLabel () "x"],
+              []
+            ),
+            ( [PsIgnore () (ExTriv (TrexVar "x"))],
+              ["x"]
+            ),
+            ( [ PsIgnore () (ExTriv (TrexVar "x")),
+                PsIgnore () (ExTriv (TrexVar "y"))
+              ],
+              ["x", "y"]
+            ),
+            ( [PsReturn () (ExTriv (TrexVar "x"))],
+              ["x"]
+            ),
+            ( [PsRequire () (TrexVar "x")],
+              ["x"]
+            ),
+            ( [PsAssert () (TrexVar "x")],
+              ["x"]
+            ),
+            ( [PsSwitch () (Switch () (TrexVar "x") [])],
+              ["x"]
+            )
+          ]
+      describe "PsDef" $ do
+        fvStmtsExamples
+          [ ( [ PsDef () "x" (ExTriv (TrexVar "y")),
+                PsIgnore () (ExTriv (TrexVar "x"))
+              ],
+              ["y"]
+            ),
+            ( [ PsDef () "x" (ExTriv (TrexConst (CBool True))),
+                PsIgnore () (ExTriv (TrexVar "y"))
+              ],
+              ["y"]
+            ),
+            ( [ PsDef () "x" (ExTriv (TrexVar "y")),
+                PsIgnore () (ExTriv (TrexVar "x")),
+                PsIgnore () (ExTriv (TrexVar "z"))
+              ],
+              ["y", "z"]
+            )
+          ]
+    describe "BodyStmts" $ do
+      fvStmtsExamples
+        [ ( [BsPublish () "x" "y"],
+            ["x", "y"]
+          )
+        ]
+
+fvStmtsExamples :: (IsStmt f, Show (f ())) => [([f ()], [Id])] -> Spec
+fvStmtsExamples = fvExamples (stmtsFreeVars . stmtsWithFreeVars)
+
+fvExamples :: Show a => (a -> Set Id) -> [(a, [Id])] -> Spec
+fvExamples getFreeVars cases =
+  for_ cases $ \(input, expected) ->
+    it ("Should return the expected result for input " <> show input) $ do
+      fvExample getFreeVars input expected
+
+fvExample :: (a -> Set Id) -> a -> [Id] -> Expectation
+fvExample getFreeVars item expected =
+  getFreeVars item `shouldBe` Set.fromList expected


### PR DESCRIPTION
N.B. this includes #22, which should be reviewed & merged first.

This patch adds code to annotation the LiftedFunctions AST with free variables, which we need for the translation pass to the BlockParamPassing AST.